### PR TITLE
Fix panic because comma in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ For example, if you want to verify the regex of `email was meant for @(a|b|c|d|e
      "parts":[
          {
              "is_public": false,
-             "regex_def": "email was meant for @",
+             "regex_def": "email was meant for @"
          },
          {
              "is_public": true,
-             "regex_def": "(a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z)+",
+             "regex_def": "(a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z)+"
          },
          {
              "is_public": false,
-             "regex_def": ".",
+             "regex_def": "."
          }
      ]
 }


### PR DESCRIPTION
Just removing the comma for the last params for each part allow zk-regex (rust) compile correctly.

Also tested against body_hash.json and compared with the current circom and both match.