### PR TITLE
README: add notes on yarn and circom

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ To understand the theory behind the regex circuit compiler, please checkout [thi
 
 ### Install
 
+Install yarn v1, or run `yarn set version classic` to set the version.
+Also make sure that [`circom`](https://docs.circom.io/getting-started/installation/) is installed.
+
 Clone the repo and install the dependencies:
 
 ```


### PR DESCRIPTION
was trying to build and test.

- had yarn v3, but needed v1.
- testing requires `circom`

suggesting to add notes on this to the README.