### PR TITLE
【Fix】 Cargo.toml file ([dependencies])

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "72832d73be48bac96a5d7944568f305d829ed55b0ce3b483647089dfaf6cf704"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -1738,6 +1738,7 @@ dependencies = [
 name = "zk-regex-compiler"
 version = "1.0.8"
 dependencies = [
+ "ahash",
  "clap",
  "fancy-regex",
  "graph-cycles",

--- a/packages/compiler/Cargo.toml
+++ b/packages/compiler/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0.159", features = ["derive"] }
 js-sandbox = { version = "0.2.0-rc.2", git = "https://github.com/Bromeon/js-sandbox.git", tag = "0.2.0-rc.2" }
 itertools = "0.10.3"
 clap = { version = "=4.2.1", features = ["derive"] }
+ahash = "=0.8.4"
 
 [dependencies.neon]
 version = "0.10"


### PR DESCRIPTION
【summary】

I ran the yarn command to use zk-regex and got an error and could not compile.

After investigating the cause and modifying the dependencies in the `Cargo.toml` file, the compilation went through, so I proposed a pull request.

【Detials of changes】

I Changed`Cargo.toml` file.

I  added ahash to the [dependencies] section.

- Before

  ```toml
  [dependencies]
  tabbycat = { version = "0.1", features = ["attributes"], optional = true }
  fancy-regex = "0.11.0"
  petgraph = "0.6.3"
  graph-cycles = "0.1.0"
  thiserror = "1.0.40"
  serde_json = "1.0.95"
  serde = { version = "1.0.159", features = ["derive"] }
  js-sandbox = { version = "0.2.0-rc.2", git = "https://github.com/Bromeon/js-sandbox.git", tag = "0.2.0-rc.2" }
  itertools = "0.10.3"
  clap = { version = "=4.2.1", features = ["derive"] }
  ```

- After
 
     ```toml
  [dependencies]
  tabbycat = { version = "0.1", features = ["attributes"], optional = true }
  fancy-regex = "0.11.0"
  petgraph = "0.6.3"
  graph-cycles = "0.1.0"
  thiserror = "1.0.40"
  serde_json = "1.0.95"
  serde = { version = "1.0.159", features = ["derive"] }
  js-sandbox = { version = "0.2.0-rc.2", git = "https://github.com/Bromeon/js-sandbox.git", tag = "0.2.0-rc.2" }
  itertools = "0.10.3"
  clap = { version = "=4.2.1", features = ["derive"] }
  ahash = "=0.8.4"
  ```

【Errors encountered during installation】
```bash
error[E0658]: use of unstable library feature 'build_hasher_simple_hash_one'
   --> /Users/harukikondo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.7/src/random_state.rs:463:5
    |
463 | /     fn hash_one<T: Hash>(&self, x: T) -> u64 {
464 | |         RandomState::hash_one(self, x)
465 | |     }
    | |_____^
    |
    = note: see issue #86161 <https://github.com/rust-lang/rust/issues/86161> for more information
    = help: add `#![feature(build_hasher_simple_hash_one)]` to the crate attributes to enable

For more information about this error, try `rustc --explain E0658`.
error: could not compile `ahash` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `zk-regex-compiler v1.0.8 (/Users/harukikondo/git/ZKRepo/zkemail/zk-regex/packages/compiler)`, intermediate artifacts can be found at `/Users/harukikondo/git/ZKRepo/zkemail/zk-regex/target`
error Command failed with exit code 101.
```

Related Error is below.

https://github.com/rust-lang/rust/issues/86161

【After modification】
![スクリーンショット 2024-01-27 15 20 57](https://github.com/zkemail/zk-regex/assets/44923695/903e0c93-0f4e-443e-ad0e-83ef11fb1bce)
