### PR TITLE
Features/HC improvements for zk-regex Noir support

### DIFF
--- a/packages/compiler/src/bin/compiler.rs
+++ b/packages/compiler/src/bin/compiler.rs
@@ -60,12 +60,14 @@ enum Commands {
     Decomposed {
         #[arg(short, long)]
         decomposed_regex_path: String,
-        #[arg(short, long)]
+        #[arg(long)]
         halo2_dir_path: Option<String>,
         #[arg(short, long)]
         circom_file_path: Option<String>,
         #[arg(short, long)]
         template_name: Option<String>,
+        #[arg(long)]
+        noir_file_path: Option<String>,
         #[arg(short, long)]
         gen_substrs: Option<bool>,
     },
@@ -74,12 +76,14 @@ enum Commands {
         raw_regex: String,
         #[arg(short, long)]
         substrs_json_path: Option<String>,
-        #[arg(short, long)]
+        #[arg(long)]
         halo2_dir_path: Option<String>,
         #[arg(short, long)]
         circom_file_path: Option<String>,
         #[arg(short, long)]
         template_name: Option<String>,
+        #[arg(long)]
+        noir_file_path: Option<String>,
         #[arg(short, long)]
         gen_substrs: Option<bool>,
     },
@@ -99,6 +103,7 @@ fn process_decomposed(cli: Cli) {
         halo2_dir_path,
         circom_file_path,
         template_name,
+        noir_file_path,
         gen_substrs,
     } = cli.command
     {
@@ -107,6 +112,7 @@ fn process_decomposed(cli: Cli) {
             halo2_dir_path.as_deref(),
             circom_file_path.as_deref(),
             template_name.as_deref(),
+            noir_file_path.as_deref(),
             gen_substrs,
         ) {
             eprintln!("Error: {}", e);
@@ -122,6 +128,7 @@ fn process_raw(cli: Cli) {
         halo2_dir_path,
         circom_file_path,
         template_name,
+        noir_file_path,
         gen_substrs,
     } = cli.command
     {
@@ -131,6 +138,7 @@ fn process_raw(cli: Cli) {
             halo2_dir_path.as_deref(),
             circom_file_path.as_deref(),
             template_name.as_deref(),
+            noir_file_path.as_deref(),
             gen_substrs,
         ) {
             eprintln!("Error: {}", e);

--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -1,6 +1,7 @@
 mod circom;
 mod errors;
 mod halo2;
+mod noir;
 mod regex;
 mod structs;
 mod wasm;
@@ -9,6 +10,7 @@ use circom::gen_circom_template;
 use errors::CompilerError;
 use halo2::gen_halo2_tables;
 use itertools::Itertools;
+use noir::gen_noir_fn;
 use regex::{create_regex_and_dfa_from_str_and_defs, get_regex_and_dfa};
 use std::{fs::File, path::PathBuf};
 use structs::{DecomposedRegexConfig, RegexAndDFA, SubstringDefinitionsJson};
@@ -55,6 +57,7 @@ fn generate_outputs(
     halo2_dir_path: Option<&str>,
     circom_file_path: Option<&str>,
     circom_template_name: Option<&str>,
+    noir_file_path: Option<&str>,
     num_public_parts: usize,
     gen_substrs: bool,
 ) -> Result<(), CompilerError> {
@@ -86,6 +89,10 @@ fn generate_outputs(
         )?;
     }
 
+    if let Some(noir_file_path) = noir_file_path {
+        gen_noir_fn(regex_and_dfa, &PathBuf::from(noir_file_path))?;
+    }
+
     Ok(())
 }
 
@@ -107,6 +114,7 @@ pub fn gen_from_decomposed(
     halo2_dir_path: Option<&str>,
     circom_file_path: Option<&str>,
     circom_template_name: Option<&str>,
+    noir_file_path: Option<&str>,
     gen_substrs: Option<bool>,
 ) -> Result<(), CompilerError> {
     let mut decomposed_regex_config: DecomposedRegexConfig =
@@ -126,6 +134,7 @@ pub fn gen_from_decomposed(
         halo2_dir_path,
         circom_file_path,
         circom_template_name,
+        noir_file_path,
         num_public_parts,
         gen_substrs,
     )?;
@@ -153,6 +162,7 @@ pub fn gen_from_raw(
     halo2_dir_path: Option<&str>,
     circom_file_path: Option<&str>,
     template_name: Option<&str>,
+    noir_file_path: Option<&str>,
     gen_substrs: Option<bool>,
 ) -> Result<(), CompilerError> {
     let substrs_defs_json = load_substring_definitions_json(substrs_json_path)?;
@@ -167,6 +177,7 @@ pub fn gen_from_raw(
         halo2_dir_path,
         circom_file_path,
         template_name,
+        noir_file_path,
         num_public_parts,
         gen_substrs,
     )?;

--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -90,7 +90,7 @@ fn generate_outputs(
     }
 
     if let Some(noir_file_path) = noir_file_path {
-        gen_noir_fn(regex_and_dfa, &PathBuf::from(noir_file_path))?;
+        gen_noir_fn(regex_and_dfa, &PathBuf::from(noir_file_path), gen_substrs)?;
     }
 
     Ok(())

--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -170,7 +170,7 @@ pub fn gen_from_raw(
 
     let regex_and_dfa = create_regex_and_dfa_from_str_and_defs(raw_regex, substrs_defs_json)?;
 
-    let gen_substrs = gen_substrs.unwrap_or(true);
+    let gen_substrs = gen_substrs.unwrap_or(false);
 
     generate_outputs(
         &regex_and_dfa,

--- a/packages/compiler/src/noir.rs
+++ b/packages/compiler/src/noir.rs
@@ -1,0 +1,115 @@
+use std::{collections::HashSet, fs::File, io::Write, iter::FromIterator, path::Path};
+
+use itertools::Itertools;
+
+use crate::structs::RegexAndDFA;
+
+const ACCEPT_STATE_ID: &str = "accept";
+
+pub fn gen_noir_fn(regex_and_dfa: &RegexAndDFA, path: &Path) -> Result<(), std::io::Error> {
+    let noir_fn = to_noir_fn(regex_and_dfa);
+    let mut file = File::create(path)?;
+    file.write_all(noir_fn.as_bytes())?;
+    file.flush()?;
+    Ok(())
+}
+
+fn to_noir_fn(regex_and_dfa: &RegexAndDFA) -> String {
+    let accept_state_ids = {
+        let accept_states = regex_and_dfa
+            .dfa
+            .states
+            .iter()
+            .filter(|s| s.state_type == ACCEPT_STATE_ID)
+            .map(|s| s.state_id)
+            .collect_vec();
+        assert!(accept_states.len() > 0, "no accept states");
+        accept_states
+    };
+
+    const BYTE_SIZE: u32 = 256; // u8 size
+    let mut lookup_table_body = String::new();
+
+    // curr_state + char_code -> next_state
+    let mut rows: Vec<(usize, u8, usize)> = vec![];
+
+    for state in regex_and_dfa.dfa.states.iter() {
+        for (&tran_next_state_id, tran) in &state.transitions {
+            for &char_code in tran {
+                rows.push((state.state_id, char_code, tran_next_state_id));
+            }
+        }
+        if state.state_type == ACCEPT_STATE_ID {
+            let existing_char_codes = &state
+                .transitions
+                .iter()
+                .flat_map(|(_, tran)| tran.iter().copied().collect_vec())
+                .collect::<HashSet<_>>();
+            let all_char_codes = HashSet::from_iter(0..=255);
+            let mut char_codes = all_char_codes.difference(existing_char_codes).collect_vec();
+            char_codes.sort(); // to be deterministic
+            for &char_code in char_codes {
+                rows.push((state.state_id, char_code, state.state_id));
+            }
+        }
+    }
+
+    for (curr_state_id, char_code, next_state_id) in rows {
+        lookup_table_body +=
+            &format!("table[{curr_state_id} * {BYTE_SIZE} + {char_code}] = {next_state_id};\n",);
+    }
+
+    lookup_table_body = indent(&lookup_table_body);
+    let table_size = BYTE_SIZE as usize * regex_and_dfa.dfa.states.len();
+    let lookup_table = format!(
+        r#"
+comptime fn make_lookup_table() -> [Field; {table_size}] {{
+    let mut table = [0; {table_size}];
+{lookup_table_body}
+
+    table
+}}
+    "#
+    );
+
+    let final_states_condition_body = accept_state_ids
+        .iter()
+        .map(|id| format!("(s == {id})"))
+        .collect_vec()
+        .join(" | ");
+    let fn_body = format!(
+        r#"
+global table = comptime {{ make_lookup_table() }};
+pub fn regex_match<let N: u32>(input: [u8; N]) {{
+    // regex: {regex_pattern}
+    let mut s = 0;
+    for i in 0..input.len() {{
+        s = table[s * {BYTE_SIZE} + input[i] as Field];
+    }}
+    assert({final_states_condition_body}, f"no match: {{s}}");
+}}
+    "#,
+        regex_pattern = regex_and_dfa.regex_pattern,
+    );
+    format!(
+        r#"
+        {fn_body}
+        {lookup_table}
+    "#
+    )
+    .trim()
+    .to_owned()
+}
+
+fn indent(s: &str) -> String {
+    s.split("\n")
+        .map(|s| {
+            if s.trim().is_empty() {
+                s.to_owned()
+            } else {
+                format!("{}{}", "    ", s)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/packages/compiler/src/noir.rs
+++ b/packages/compiler/src/noir.rs
@@ -179,8 +179,6 @@ global table = comptime {{ make_lookup_table() }};
 pub fn regex_match<let N: u32>(input: [u8; N]) -> Vec<BoundedVec<Field, N>> {{
     // regex: {regex_pattern}
     let mut substrings: Vec<BoundedVec<Field, N>> = Vec::new();
-    // Workaround for pop bug with Vec
-    let mut substr_count = 0;
 
     // "Previous" state
     let mut s: Field = 0;

--- a/packages/compiler/src/noir.rs
+++ b/packages/compiler/src/noir.rs
@@ -1,20 +1,32 @@
-use std::{collections::HashSet, fs::File, io::Write, iter::FromIterator, path::Path};
-
-use itertools::Itertools;
-
 use crate::structs::RegexAndDFA;
+use itertools::Itertools;
+use std::{collections::HashSet, fs::File, io::Write, iter::FromIterator, path::Path};
 
 const ACCEPT_STATE_ID: &str = "accept";
 
-pub fn gen_noir_fn(regex_and_dfa: &RegexAndDFA, path: &Path) -> Result<(), std::io::Error> {
-    let noir_fn = to_noir_fn(regex_and_dfa);
+pub fn gen_noir_fn(
+    regex_and_dfa: &RegexAndDFA,
+    path: &Path,
+    gen_substrs: bool,
+) -> Result<(), std::io::Error> {
+    let noir_fn = to_noir_fn(regex_and_dfa, gen_substrs);
     let mut file = File::create(path)?;
     file.write_all(noir_fn.as_bytes())?;
     file.flush()?;
     Ok(())
 }
 
-fn to_noir_fn(regex_and_dfa: &RegexAndDFA) -> String {
+/// Generates Noir code based on the DFA and whether a substring should be extracted.
+///
+/// # Arguments
+///
+/// * `regex_and_dfa` - The `RegexAndDFA` struct containing the regex pattern and DFA.
+/// * `gen_substrs` - A boolean indicating whether to generate substrings. 
+///
+/// # Returns
+///
+/// A `String` that contains the Noir code
+fn to_noir_fn(regex_and_dfa: &RegexAndDFA, gen_substrs: bool) -> String {
     let accept_state_ids = {
         let accept_states = regex_and_dfa
             .dfa
@@ -59,7 +71,7 @@ fn to_noir_fn(regex_and_dfa: &RegexAndDFA) -> String {
             &format!("table[{curr_state_id} * {BYTE_SIZE} + {char_code}] = {next_state_id};\n",);
     }
 
-    lookup_table_body = indent(&lookup_table_body);
+    lookup_table_body = indent(&lookup_table_body, 1);
     let table_size = BYTE_SIZE as usize * regex_and_dfa.dfa.states.len();
     let lookup_table = format!(
         r#"
@@ -72,13 +84,78 @@ comptime fn make_lookup_table() -> [Field; {table_size}] {{
     "#
     );
 
+    // substring_ranges contains the transitions that belong to the substring. 
+    //   in Noir we only need to know in what state the substring needs to be extracted, the transitions are not needed
+    //   Example: SubstringDefinitions { substring_ranges: [{(2, 3)}, {(6, 7), (7, 7)}, {(8, 9)}], substring_boundaries: None }
+    //   for each substring, get the first transition and get the end state
+    let substr_states: Vec<usize> = regex_and_dfa
+      .substrings
+      .substring_ranges
+      .iter()
+      .flat_map(|range_set| range_set.iter().next().map(|&(_, end_state)| end_state)) // Extract the second element (end state) of each tuple
+      .collect();
+    // Note: substring_boundaries is only filled if the substring info is coming from decomposed setting
+    //  and will be empty in the raw setting (using json file for substr transitions). This is why substring_ranges is used here
+
     let final_states_condition_body = accept_state_ids
         .iter()
         .map(|id| format!("(s == {id})"))
         .collect_vec()
         .join(" | ");
-    let fn_body = format!(
-        r#"
+
+    // If substrings have to be extracted, the function returns that amount of BoundedVec,
+    // otherwise there is no return type
+    let fn_body = if gen_substrs {
+        let nr_substrs = substr_states.len();
+        // Initialize a substring BoundedVec for each substr that has to be extracted
+        let mut bounded_vecs_initialization = (0..nr_substrs)
+            .map(|index| format!("let mut substr{} = BoundedVec::new();", index))
+            .collect::<Vec<_>>()
+            .join("\n");
+        bounded_vecs_initialization = indent(&bounded_vecs_initialization, 1); // Indent once for inside the function
+
+        // Fill each substring when at the corresponding state
+        let mut conditions = substr_states
+            .iter()
+            .enumerate()
+            .map(|(index, state)| {
+                format!(
+                    "if (s == {state}) {{
+    substr{index_plus_one}.push(temp);
+}}",
+                    index_plus_one = index
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        conditions = indent(&conditions, 2); // Indent twice to align with the for loop's body
+
+        format!(
+            r#"
+global table = comptime {{ make_lookup_table() }};
+pub fn regex_match<let N: u32>(input: [u8; N]) -> [BoundedVec<Field, N>; {nr_substrs}] {{
+    // regex: {regex_pattern}
+    let mut s = 0;
+    
+{bounded_vecs_initialization}
+
+    for i in 0..input.len() {{
+        let temp = input[i] as Field;
+        s = table[s * {BYTE_SIZE} + input[i] as Field];
+{conditions}
+    }}
+    assert({final_states_condition_body}, f"no match: {{s}}");
+    [{bounded_vec_names}]
+}}"#,
+            regex_pattern = regex_and_dfa.regex_pattern,
+            bounded_vec_names = (0..nr_substrs)
+                .map(|index| format!("substr{}", index))
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    } else {
+        format!(
+            r#"
 global table = comptime {{ make_lookup_table() }};
 pub fn regex_match<let N: u32>(input: [u8; N]) {{
     // regex: {regex_pattern}
@@ -87,10 +164,11 @@ pub fn regex_match<let N: u32>(input: [u8; N]) {{
         s = table[s * {BYTE_SIZE} + input[i] as Field];
     }}
     assert({final_states_condition_body}, f"no match: {{s}}");
-}}
-    "#,
-        regex_pattern = regex_and_dfa.regex_pattern,
-    );
+}}"#,
+            regex_pattern = regex_and_dfa.regex_pattern,
+        )
+    };
+
     format!(
         r#"
         {fn_body}
@@ -101,13 +179,16 @@ pub fn regex_match<let N: u32>(input: [u8; N]) {{
     .to_owned()
 }
 
-fn indent(s: &str) -> String {
+/// Indents each line of the given string by a specified number of levels.
+/// Each level adds four spaces to the beginning of non-whitespace lines.
+fn indent(s: &str, level: usize) -> String {
+    let indent_str = "    ".repeat(level);
     s.split("\n")
         .map(|s| {
             if s.trim().is_empty() {
                 s.to_owned()
             } else {
-                format!("{}{}", "    ", s)
+                format!("{}{}", indent_str, s)
             }
         })
         .collect::<Vec<_>>()

--- a/packages/compiler/src/noir.rs
+++ b/packages/compiler/src/noir.rs
@@ -218,7 +218,7 @@ pub fn regex_match<let N: u32>(input: [u8; N]) -> Vec<BoundedVec<Field, N>> {{
     }}
     substrings
 }}"#,
-            regex_pattern = regex_and_dfa.regex_pattern
+            regex_pattern = regex_and_dfa.regex_pattern.replace('\n', "\\n").replace('\r', "\\r")
         )
     } else {
         format!(
@@ -233,7 +233,7 @@ pub fn regex_match<let N: u32>(input: [u8; N]) {{
     }}
     assert({final_states_condition_body}, f"no match: {{s}}");
 }}"#,
-            regex_pattern = regex_and_dfa.regex_pattern,
+            regex_pattern = regex_and_dfa.regex_pattern.replace('\n', "\\n").replace('\r', "\\r"),
         )
     };
 


### PR DESCRIPTION
This PR was previously opened [here](https://github.com/noir-lang/zk-regex/pull/8). 
# Description

This PR contains implementation of features `gen_substrs`, `ˆ` support, `$` support and overall bugfixes for the Noir support.

This branch has been tested equally as the circom implementation. 
All circom tests from the original [zk-regex](https://github.com/zkemail/zk-regex) lib have been added in the [test-suite](https://github.com/hashcloak/zk-regex-tests-and-examples/tree/main/test_suite). All tests pass with the added features and bugfixes. 

- `ˆ` support is realized by prefixing the input array by 255. This is the same in circom
- `$` support is realized by adding an additional accepting state, to which the previous accepting state transitions for any character. This new state is then added to the accepting states. In the case that `$` is at the end of the regex this extra transition is not done and inputs continuing after `$` are thus rejected. This solution increases the lookup table size by 255 rows
- `gen_substrs` lets us extract substrings alongside the regex check. This can be done via `decomposed` or `raw` setting. 
  - substring is extracted based on transition information in the DFA
  - the return type per substring is `BoundedVec<Field,N>`, because we don't know the exact length beforehand
  - the total return type for the `regex_match` function with substring extraction is `Vec<BoundedVec<Field,N>>` because the total number of substrings is not always known beforehand
  - only if a substring is part of a valid regex it is added to return output (similar to the `consecutive` check in circom)
  - the implementation strategy for `$` is needed also to extract the exact correct substring (otherwise it would just keep extracting until the end of the input)
  - we set `gen_substrs` in `raw` to default (this is a change outside of the Noir code, but seemed to make sense)
- fix: introduction of a "reset" in state. If the next state is 0, we need to consider a possible transition from state 0 at the current moment as well. Example: regex `ab` and input `aab`. For the first input `a` it moves into state 1. For the second input `a` it moves into state 0. And then it would stay there. Now, we're adding the possibility for the 2nd occurrence of `a` to move into state 1 again. 

Note: multiple accepting states that would occur directly from the regex are not supported, same as in the circom impl. (See README comment of original lib [here](https://github.com/zkemail/zk-regex/blob/main/README.md?plain=1#L38)). 

This replaces previously opened PRs: https://github.com/noir-lang/zk-regex/pull/2 and https://github.com/noir-lang/zk-regex/pull/1. (Although the steps for manual verification are still valid)

## Additional Context

The test suite is built specifically for the Noir zk-regex library. From a database of regex inputs + samples it will generate the required Noir code, create the desired tests and run them. The [database](https://github.com/hashcloak/zk-regex-tests-and-examples/blob/main/test_suite/regex_db.json) has been filled with the equivalents of the tests for circom. Additionally, there are 2 hardcoded [test projects](https://github.com/hashcloak/zk-regex-tests-and-examples/tree/main/test_suite/hardcoded_tests) for the circom tests that had more complex circuits (combining multiple templates). 

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
