### PR TITLE
Fix double backslash error in the zk-regex compiler

### DIFF
--- a/packages/compiler/src/regex.rs
+++ b/packages/compiler/src/regex.rs
@@ -327,7 +327,7 @@ fn create_special_char_mappings() -> BTreeMap<&'static str, u8> {
         ("\\0", 0),
         ("\\\"", 34),
         ("\\'", 39),
-        ("\\", 92),
+        ("\\\\", 92),
         ("' '", 32),
     ]
     .iter()


### PR DESCRIPTION
This PR fixes a bug in the zk-regex compiler.
It allows using "\\" in the regex definition. 