### PR TITLE
Fix Potential Overflow Vulnerability in LessThan(8) Usage

### DIFF
--- a/packages/circom/circuits/common/body_hash_regex.circom
+++ b/packages/circom/circuits/common/body_hash_regex.circom
@@ -3,7 +3,7 @@ pragma circom 2.1.5;
 include "@zk-email/zk-regex-circom/circuits/regex_helpers.circom";
 
 // regex: (\r\n|^)dkim-signature:([a-z]+=[^;]+; )+bh=[a-zA-Z0-9+/=]+;
-template BodyHashRegex(msg_bytes) {
+template BodyHashRegex(msg_bytes, is_safe) {
 	signal input msg[msg_bytes];
 	signal output out;
 
@@ -12,6 +12,9 @@ template BodyHashRegex(msg_bytes) {
 	signal in_range_checks[msg_bytes];
 	in[0]<==255;
 	for (var i = 0; i < msg_bytes; i++) {
+		if is_safe {
+			Num2Bits(8)(msg[i]);
+		}
 		in_range_checks[i] <== LessThan(8)([msg[i], 255]);
 		in_range_checks[i] === 1;
 		in[i+1] <== msg[i];

--- a/packages/circom/tests/circuits/test_body_hash_regex.circom
+++ b/packages/circom/tests/circuits/test_body_hash_regex.circom
@@ -2,4 +2,4 @@ pragma circom 2.1.5;
 
 include "../../circuits/common/body_hash_regex.circom";
 
-component main = BodyHashRegex(1024);
+component main = BodyHashRegex(1024, 0);


### PR DESCRIPTION
Hi!

Thank you for this fantastic project! While exploring the code, I noticed that LessThan(8) is used in several templates to validate the range of the input msg. However, this function does not check the bit-length of msg, which can result in potential security vulnerabilities.

## Issue Overview:

The `LessThan(N)` function in Circomlib has a known overflow vulnerability. When handling values exceeding `N` bits, it can produce unexpected results. For instance, in this project, the intended behavior seems to be ensuring `LessThan(8)` outputs `out = 0` if msg[i] exceeds 255.

However, for an input like:
`msg[i] = 21888242871839275222246405745257275088548364400416034343698204186575808495616`
(which I discovered using a fuzzing tool), the `LessThan(8)` function incorrectly outputs `out = 1`, allowing a valid proof to be generated.

- example

https://github.com/zkemail/zk-regex/blob/b7bb363f57621e15ea59683ec410450984a7b899/packages/circom/circuits/common/body_hash_regex.circom#L15

I confirmed that:

- A proof for BodyHashRegex(1) cannot be generated with an input like `{"msg": ["256"]}`.
- However, a proof can be generated for `{"msg": ["21888242871839275222246405745257275088548364400416034343698204186575808495616"]}`, despite this input clearly exceeding the intended range.

## Changes in This PR:

To address this issue, I added a template-parameter option that adds Num2Bits, which inherently validates the bit-length of the input. This ensures that inputs are constrained correctly and prevents unintended overflow behavior.

## Additional Context:

For further details on this type of vulnerability, see:
https://github.com/BlakeMScurr/comparator-overflow