### PR TITLE
fix: add missing closing brace in circom template when gen_substrs=false

### DIFF
--- a/packages/compiler/src/circom.rs
+++ b/packages/compiler/src/circom.rs
@@ -980,6 +980,8 @@ pub(crate) fn gen_circom_template(
     if gen_substrs {
         let substrs = add_substrs_constraints(regex_and_dfa)?;
         file.write_all(substrs.as_bytes())?;
+    } else {
+        file.write_all(b"}")?;
     }
 
     file.flush()?;


### PR DESCRIPTION
## Problem
`gen_circom_template` was missing closing brace `}` when `gen_substrs=false`, 
generating invalid circom files for CLI commands.

## Root Cause
- `gen_circom_allstr()` doesn't include closing brace
- `add_substrs_constraints()` adds the closing brace
- When `gen_substrs=false`, only `gen_circom_allstr()` output was written

## Solution
Added `else` block to write closing brace `}` when substrings are not generated.

## Impact
- Fixes CLI commands with `gen_substrs=false`
- No impact on existing functionality
- All generated circom files now have valid syntax