### PR TITLE
fix: correct spelling in comment

### DIFF
--- a/packages/apis/src/extract_substrs.rs
+++ b/packages/apis/src/extract_substrs.rs
@@ -60,7 +60,7 @@ pub fn extract_substr_idxes(
     }
 
     // Compile the entire regex
-    // This should be impossible to fail, since we tested the seperate regex parts before.
+    // This should be impossible to fail, since we tested the separate regex parts before.
     let entire_regex = Regex::new(&entire_regex_str).unwrap();
 
     // Find the match for the entire regex


### PR DESCRIPTION
## Description
Fixed spelling error in code comment.

⚠️ **Note:** Comment-only change. No functional code modified.

## Changes
- Fix 'seperate' → 'separate'

## Files Modified
- packages/apis/src/extract_substrs.rs

## Impact
- Comment clarity improvement only
- No functional changes to ZK regex logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a spelling error in an internal comment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkemail/zk-regex/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->